### PR TITLE
fix:Define explicitly about the types

### DIFF
--- a/helloWorld.c
+++ b/helloWorld.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
 
-main()
+int main(void)
 {
 	printf("hello, world\n");
+	return 0;
 }
 


### PR DESCRIPTION
The existing main function is missing definitions
of the arguments and the return. It was probably
written with consciousness of K&R. However, it is
not recommended to omit descriptions about types
in C nowadays.